### PR TITLE
Run a real ensemble using real storage

### DIFF
--- a/charts/zenko-zookeeper/templates/statefulset.yaml
+++ b/charts/zenko-zookeeper/templates/statefulset.yaml
@@ -28,8 +28,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ template "zookeeper.name" . }}-server
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
-        image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:

--- a/charts/zenko-zookeeper/templates/statefulset.yaml
+++ b/charts/zenko-zookeeper/templates/statefulset.yaml
@@ -69,8 +69,9 @@ spec:
           timeoutSeconds: {{ .Values.probeTimeoutSeconds }}
         volumeMounts:
         - name: datadir
-          mountPath: /var/lib/zookeeper
-          subPath: data
+          mountPath: /data
+        - name: datalogdir
+          mountPath: /datalog
       {{- if eq .Values.security.enabled true }}
       securityContext:
         runAsUser: {{ .Values.security.runAsUser }}
@@ -83,7 +84,17 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: {{ .Values.storage }}
-      {{- if .Values.storageClass }}
-      storageClassName: {{ .Values.storageClass | quote }}
+          storage: {{ .Values.storage.data.size | quote }}
+      {{- if .Values.storage.data.storageClass }}
+      storageClassName: {{ .Values.storage.data.storageClass | quote }}
+      {{- end }}
+  - metadata:
+      name: datalogdir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.storage.log.size | quote }}
+      {{- if .Values.storage.log.storageClass }}
+      storageClassName: {{ .Values.storage.log.storageClass | quote }}
       {{- end }}

--- a/charts/zenko-zookeeper/values.yaml
+++ b/charts/zenko-zookeeper/values.yaml
@@ -12,7 +12,6 @@ resources:
     cpu: 1
     memory: 4Gi
 heap: "2G"
-imagePullPolicy: "IfNotPresent"
 tickTimeMs: 2000
 initTicks: 10
 syncTicks: 5
@@ -26,8 +25,11 @@ security:
   enabled: false
   runAsUser: 1000
   fsGroup: 1000
-Image: docker.io/zenko/zenko-zookeeper
-ImageTag: 0.0.2
+
+image:
+  repository: docker.io/zenko/zenko-zookeeper
+  tag: 0.0.2
+  pullPolicy: IfNotPresent
 
 storage:
   data:

--- a/charts/zenko-zookeeper/values.yaml
+++ b/charts/zenko-zookeeper/values.yaml
@@ -12,8 +12,6 @@ resources:
     cpu: 1
     memory: 4Gi
 heap: "2G"
-storage: "50Gi"
-# storageClass: default
 imagePullPolicy: "IfNotPresent"
 tickTimeMs: 2000
 initTicks: 10
@@ -30,6 +28,14 @@ security:
   fsGroup: 1000
 Image: docker.io/zenko/zenko-zookeeper
 ImageTag: 0.0.2
+
+storage:
+  data:
+    size: 10Gi
+    # storageClass: default
+  log:
+    size: 50Gi
+    # storageClass: default
 
 # Affinities to add to the worker pods.
 # Useful if you prefer to run workers on non-spot instances, for example

--- a/images/zenko-zookeeper/Dockerfile
+++ b/images/zenko-zookeeper/Dockerfile
@@ -52,7 +52,7 @@ LABEL maintainer="zenko-platform@scality.com" \
       org.label-schema.vendor="Scality" \
       org.label-schema.version="$VERSION" \
       org.label-schema.schema-version="1.0" \
-      org.label-schema.docker.cmd="docker run -p $ZOO_PORT:$ZOO_PORT -p $PROMETHEUS_AGENT_PORT:$PROMETHEUS_AGENT_PORT -h zookeeper-0 -e ZOO_REPLICAS=1 scality/zenko-zookeeper" \
+      org.label-schema.docker.cmd="docker run -p $ZOO_PORT:$ZOO_PORT -p $PROMETHEUS_AGENT_PORT:$PROMETHEUS_AGENT_PORT -h zookeeper-0 -e ZOO_REPLICAS=1 zenko/zenko-zookeeper" \
       org.label-schema.docker.debug="docker exec -it \$CONTAINER zkCli.sh" \
       org.label-schema.docker.params="PROMETHEUS_AGENT_PORT=port of Prometheus exporter,ZOO_REPLICAS=number of Zookeeper replicas in the ensemble" \
       # https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/images/zenko-zookeeper/kubernetes-entrypoint.sh
+++ b/images/zenko-zookeeper/kubernetes-entrypoint.sh
@@ -34,7 +34,6 @@ function compute_server_list() {
     if [ -z $ZOO_REPLICAS ]; then
         die "ZOO_REPLICAS is a mandatory environment variable"
     fi
-    local ZOO_SERVERS
     ZOO_SERVERS=""
     for (( i=1; i<=$ZOO_REPLICAS; i++ ))
     do

--- a/images/zenko-zookeeper/kubernetes-entrypoint.sh
+++ b/images/zenko-zookeeper/kubernetes-entrypoint.sh
@@ -51,7 +51,7 @@ function create_java_env() {
 # SERVER_JVMFLAGS only: no need to have a huge heap for zkCli, and loading the
 # Prometheus agent on the same port would make it go nuts.
 SERVER_JVMFLAGS="-Xmx$ZOO_HEAP_SIZE -Xms$ZOO_HEAP_SIZE"
-SERVER_JVMFLAGS="\${JVMFLAGS} -javaagent:${PROMETHEUS_AGENT_JAR}=${PROMETHEUS_AGENT_PORT}:${PROMETHEUS_AGENT_CONFIG}"
+SERVER_JVMFLAGS="\${SERVER_JVMFLAGS} -javaagent:${PROMETHEUS_AGENT_JAR}=${PROMETHEUS_AGENT_PORT}:${PROMETHEUS_AGENT_CONFIG}"
 EOF
     # echo "ZOO_LOG_DIR=$ZOO_LOG_DIR" >> $JAVA_ENV_FILE
     echo "Wrote JVM configuration to $JAVA_ENV_FILE"


### PR DESCRIPTION
Due to a mistake in dbddd15c56ffe5b49a1197cae57dc95492cbcb1c, when this Chart was deployed we simply ran a couple of stand-alone servers, rather than a real Zookeeper ensemble.

This issue is so major we should retract prior releases of the Chart and Docker images.