### PR TITLE
Enhance Pod lifecycle management

### DIFF
--- a/charts/zenko-zookeeper/templates/statefulset.yaml
+++ b/charts/zenko-zookeeper/templates/statefulset.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
   serviceName: {{ template "zookeeper.fullname" . }}-headless
   replicas: {{ .Values.servers }}
   template:

--- a/charts/zenko-zookeeper/templates/statefulset.yaml
+++ b/charts/zenko-zookeeper/templates/statefulset.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  podManagementPolicy: Parallel
   serviceName: {{ template "zookeeper.fullname" . }}-headless
   replicas: {{ .Values.servers }}
   template:


### PR DESCRIPTION
There are a couple of ways in which the lifecycle of `Pod`s in a `StatefulSet` can be influenced. These commits allow for concurrent startup of such `Pod`s, as well as rolling updates when applying template changes.